### PR TITLE
Fix logic and formatting

### DIFF
--- a/CCAutosplitter.asl
+++ b/CCAutosplitter.asl
@@ -9,7 +9,7 @@ state("CrabChampions-Win64-Shipping")
 	//level and gamestate are actually both stored as 4 bytes, in case you want to search in CE easier.
 	byte level : 0x04299B00, 0x120, 0x2A8;
 	byte gamestate : 0x04299B00, 0x120, 0x278;
-	
+
 	//this is only a readout of the current health, not the actual health
 	float health : 0x04282120, 0x30, 0x228, 0x38C;
 }
@@ -54,7 +54,7 @@ gamestate 7: loading (crab splash screen)
 
 start{
 	//level 0 is lobby
-	if (current.level == 0 & current.gamestate == 2) {
+	if (current.level == 0 && current.gamestate == 2) {
 		print("[CrabAutoSplit] RUN START");
 		return true;
 	};
@@ -71,9 +71,9 @@ isLoading{
 
 split{
 	//detect level change (0 check is to prevent it from spamming splits when starting a new run)
-	if (current.level != old.level & old.level > 0) {
+	if (current.level != old.level && old.level > 0) {
 			print("[CrabAutoSplit] LEVEL CHANGED!");
-			if (settings["split15"] == true) {  
+			if (settings["split15"] == true) {
 				print("[CrabAutoSplit] 15 SPLIT ENABLED");
 				if ((current.level - 1) % 15 == 0) {
 					print("[CrabAutoSplit] SPLIT DONE!");
@@ -89,32 +89,32 @@ split{
 				};
 			};
 
-			if (settings["split5"] == true) {  
+			if (settings["split5"] == true) {
 				print("[CrabAutoSplit] 5 SPLIT ENABLED");
 				if ((current.level - 1) % 5 == 0) {
 					print("[CrabAutoSplit] SPLIT DONE!");
 					return true;
 				};
 			};
-			
-			if (settings["split1"] == true) {  
+
+			if (settings["split1"] == true) {
 				print("[CrabAutoSplit] SPLIT AT 1");
 				print("[CrabAutoSplit] SPLIT DONE!");
 				return true;
 			};
-			
+
 			//in case no settings are picked, for some reason
 			print("[CrabAutoSplit] NO SPLIT DONE BY US");
 			return false;
 	};
 
 	/*
-	TODO: Make sure this doesn't split if you die at the boss level. 
-	Currently the game seems to set your health to 1 even when you're dead? 
-	This could potentially trigger splits at death instead of only victory 
+	TODO: Make sure this doesn't split if you die at the boss level.
+	Currently the game seems to set your health to 1 even when you're dead?
+	This could potentially trigger splits at death instead of only victory
 	*/
 	if (current.gamestate == 6 && current.health > 1) {
-		if (current.level == 30 | 60 | 90 | 120) {
+		if (current.level == 30 || current.level == 60 || current.level 90 || current.level == 120) {
 			print("[CrabAutoSplit] VICTORY SCREEN");
 			return true;
 		};
@@ -123,7 +123,7 @@ split{
 
 reset{
 	//New setting for loading screen reset
-	if (settings["reset"] == true) { 
+	if (settings["reset"] == true) {
 		if (current.gamestate == 7) {
 		print("[CrabAutoSplit] SPLITS RESET");
 		return true;

--- a/CCAutosplitter.asl
+++ b/CCAutosplitter.asl
@@ -20,7 +20,6 @@ init{
 
 startup{
 	print("[CrabAutoSplit] STARTUP");
-	settings.Add("reset", true, "Reset splits on returning to Lobby");
 
 	settings.Add("comment", true, "Only use one level split at a time!");
 	settings.Add("split1", false, "Split Every Level", "comment");
@@ -31,15 +30,13 @@ startup{
 
 update{
 	/*
-	if (current.level != old.level & old.level > 0) {
+	if (old.level != current.level && old.level > 0) {
 		print("[CrabAutoSplit] UPDATE");
 		print("[CrabAutoSplit] " + current.level);
 		print("[CrabAutoSplit] " +current.gamestate);
 		print("[CrabAutoSplit] " +current.health);
-		return true;
 	}
 	*/
-	return true;
 }
 
 /*
@@ -54,26 +51,21 @@ gamestate 7: loading (crab splash screen)
 
 start{
 	//level 0 is lobby
-	if (current.level == 0 && current.gamestate == 2) {
+	if (old.gamestate == 1 && current.gamestate == 2 && current.level == 0) {
 		print("[CrabAutoSplit] RUN START");
 		return true;
 	};
 }
 
 isLoading{
-	if(current.gamestate == 2){
-		return true;
-	};
-	if(current.gamestate != 2){
-		return false;
-	};
+	return current.gamestate == 2;
 }
 
 split{
 	//detect level change (0 check is to prevent it from spamming splits when starting a new run)
-	if (current.level != old.level && old.level > 0) {
+	if (old.level != current.level && old.level > 0) {
 			print("[CrabAutoSplit] LEVEL CHANGED!");
-			if (settings["split15"] == true) {
+			if (settings["split15"]) {
 				print("[CrabAutoSplit] 15 SPLIT ENABLED");
 				if ((current.level - 1) % 15 == 0) {
 					print("[CrabAutoSplit] SPLIT DONE!");
@@ -81,7 +73,7 @@ split{
 				};
 			};
 
-			if (settings["split10"] == true) {
+			if (settings["split10"]) {
 				print("[CrabAutoSplit] 10 SPLIT ENABLED");
 				if ((current.level - 1) % 10 == 0) {
 					print("[CrabAutoSplit] SPLIT DONE!");
@@ -89,7 +81,7 @@ split{
 				};
 			};
 
-			if (settings["split5"] == true) {
+			if (settings["split5"]) {
 				print("[CrabAutoSplit] 5 SPLIT ENABLED");
 				if ((current.level - 1) % 5 == 0) {
 					print("[CrabAutoSplit] SPLIT DONE!");
@@ -97,7 +89,7 @@ split{
 				};
 			};
 
-			if (settings["split1"] == true) {
+			if (settings["split1"]) {
 				print("[CrabAutoSplit] SPLIT AT 1");
 				print("[CrabAutoSplit] SPLIT DONE!");
 				return true;
@@ -105,7 +97,6 @@ split{
 
 			//in case no settings are picked, for some reason
 			print("[CrabAutoSplit] NO SPLIT DONE BY US");
-			return false;
 	};
 
 	/*
@@ -123,7 +114,7 @@ split{
 
 reset{
 	//New setting for loading screen reset
-	if (settings["reset"] == true) {
+	if (settings["reset"]) {
 		if (current.gamestate == 7) {
 		print("[CrabAutoSplit] SPLITS RESET");
 		return true;

--- a/CCAutosplitter.asl
+++ b/CCAutosplitter.asl
@@ -1,123 +1,58 @@
-/*
-Created by Mitz, find me on the official Crab Champions Speedrunning Discord!
-v0.123
-for version Early Access 1772 - Update 3
-*/
+state("CrabChampions-Win64-Shipping") {
+	// 1: lobby
+	// 2: loading (between levels)
+	// 3: island in progress
+	// 4: island complete
+	// 5: activated victory crown
+	// 6: victory screen, death screen
+	// 7: loading (crab splash screen)
+	int   gamestate : 0x4299B00, 0x120, 0x278;
 
-state("CrabChampions-Win64-Shipping")
-{
-	//level and gamestate are actually both stored as 4 bytes, in case you want to search in CE easier.
-	byte level : 0x04299B00, 0x120, 0x2A8;
-	byte gamestate : 0x04299B00, 0x120, 0x278;
-
-	//this is only a readout of the current health, not the actual health
-	float health : 0x04282120, 0x30, 0x228, 0x38C;
+	int   level     : 0x4299B00, 0x120, 0x2A8;
+	float health    : 0x4282120, 0x30, 0x228, 0x38C; // read-out of the current health, not the actual health
 }
 
-init{
-	print("[CrabAutoSplit] INIT");
+startup {
+	settings.Add("splits", true, "Split on level completion (only check one):");
+		settings.Add("split1", false, "Every Level", "splits");
+		settings.Add("split5", true, "Every 5 Levels", "splits");
+		settings.Add("split10", false, "Every 10 Levels", "splits");
+		settings.Add("split15", false, "Every 15 Levels", "splits");
 }
 
-startup{
-	print("[CrabAutoSplit] STARTUP");
-
-	settings.Add("comment", true, "Only use one level split at a time!");
-	settings.Add("split1", false, "Split Every Level", "comment");
-	settings.Add("split5", true, "Split Every 5 Levels (Default)", "comment");
-	settings.Add("split10", false, "Split Every 10 Levels", "comment");
-	settings.Add("split15", false, "Split Every 15 Levels", "comment");
+start {
+	return old.gamestate == 1 && current.gamestate == 2
+		&& current.level == 0;
 }
 
-update{
-	/*
+split {
+	// detect level change (check against 0 to avoid splitting at start)
 	if (old.level != current.level && old.level > 0) {
-		print("[CrabAutoSplit] UPDATE");
-		print("[CrabAutoSplit] " + current.level);
-		print("[CrabAutoSplit] " +current.gamestate);
-		print("[CrabAutoSplit] " +current.health);
+		int lvl = current.level - 1;
+
+		return settings["split1"]
+			|| settings["split5"] && lvl % 5 == 0
+			|| settings["split10"] && lvl % 10 == 0
+			|| settings["split15"] && lvl % 15 == 0;
 	}
-	*/
+
+
+	// TODO: Make sure this doesn't split if you die at the boss level.
+	// Currently the game seems to set your health to 1 even when you're dead?
+	// This could potentially trigger splits at death instead of only victory
+	//
+	if (old.gamestate != 6 && current.gamestate == 6 && current.health > 1) {
+		return current.level == 30
+			|| current.level == 60
+			|| current.level == 90
+			|| current.level == 120;
+	}
 }
 
-/*
-gamestate 1: lobby
-gamestate 2: loading (between levels)
-gamestate 3: island in progress
-gamestate 4: island complete
-gamestate 5: activated victory crown
-gamestate 6: victory screen, death screen
-gamestate 7: loading (crab splash screen)
-*/
-
-start{
-	//level 0 is lobby
-	if (old.gamestate == 1 && current.gamestate == 2 && current.level == 0) {
-		print("[CrabAutoSplit] RUN START");
-		return true;
-	};
+reset {
+	return old.gamestate != 7 && current.gamestate == 7;
 }
 
-isLoading{
+isLoading {
 	return current.gamestate == 2;
-}
-
-split{
-	//detect level change (0 check is to prevent it from spamming splits when starting a new run)
-	if (old.level != current.level && old.level > 0) {
-			print("[CrabAutoSplit] LEVEL CHANGED!");
-			if (settings["split15"]) {
-				print("[CrabAutoSplit] 15 SPLIT ENABLED");
-				if ((current.level - 1) % 15 == 0) {
-					print("[CrabAutoSplit] SPLIT DONE!");
-					return true;
-				};
-			};
-
-			if (settings["split10"]) {
-				print("[CrabAutoSplit] 10 SPLIT ENABLED");
-				if ((current.level - 1) % 10 == 0) {
-					print("[CrabAutoSplit] SPLIT DONE!");
-					return true;
-				};
-			};
-
-			if (settings["split5"]) {
-				print("[CrabAutoSplit] 5 SPLIT ENABLED");
-				if ((current.level - 1) % 5 == 0) {
-					print("[CrabAutoSplit] SPLIT DONE!");
-					return true;
-				};
-			};
-
-			if (settings["split1"]) {
-				print("[CrabAutoSplit] SPLIT AT 1");
-				print("[CrabAutoSplit] SPLIT DONE!");
-				return true;
-			};
-
-			//in case no settings are picked, for some reason
-			print("[CrabAutoSplit] NO SPLIT DONE BY US");
-	};
-
-	/*
-	TODO: Make sure this doesn't split if you die at the boss level.
-	Currently the game seems to set your health to 1 even when you're dead?
-	This could potentially trigger splits at death instead of only victory
-	*/
-	if (current.gamestate == 6 && current.health > 1) {
-		if (current.level == 30 || current.level == 60 || current.level 90 || current.level == 120) {
-			print("[CrabAutoSplit] VICTORY SCREEN");
-			return true;
-		};
-	};
-}
-
-reset{
-	//New setting for loading screen reset
-	if (settings["reset"]) {
-		if (current.gamestate == 7) {
-		print("[CrabAutoSplit] SPLITS RESET");
-		return true;
-		};
-	};
 }


### PR DESCRIPTION
* Use conditional operators `&&` and `||` to check conditions
  * C# has short-circuiting, if one condition in the chain does not meet the requirements, we no longer need to check any others. conditional operators fulfill this, bit-wise operators (`&`, `|`) do not.
  * The previous logic `current.level == 30 | 60 | 90 | 120` does not do what you think it does; this checks `current.level == 126`.
* Only execute things on a rising edge
  * Check both `old` and `current` to only do something on a real change.
* Compact settings
  * "Reset" is already a default setting, no need to duplicate it.
  * Just renamed some things to make it more clear and concise.
* Remove debug prints
  * The end user will never see these and they needlessly disrupt the code flow.
  * Let me know if you'd like me to add them back in as comments.

Test before merging.